### PR TITLE
README: specify plugin author on install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Manage todo lists with ease. Powerful, easy to use and customizable.
 Run the following in the command palette:
 
 ```shell
-ext install vscode-todo-plus
+ext install fabiospampinato.vscode-todo-plus
 ```
 
 ## Usage


### PR DESCRIPTION
Running `ext install vscode-todo-plus` won't find the plugin on the marketplace. 

Adding the author on the command would make the trick :)

![feb-01-2018 17-59-32](https://user-images.githubusercontent.com/17926167/35692049-868ae976-077a-11e8-8ecc-debf7c71c558.gif)
