### PR TITLE
added taskpaper on keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -285,7 +285,8 @@
     "extension",
     "todo",
     "todos",
-    "tasks"
+    "tasks",
+    "taskpaper"
   ],
   "categories": [
     "Other"


### PR DESCRIPTION
Searching for `TaskPaper` in the VSCode Plugin Search does not locate this plugin (Todo+)