### PR TITLE
Exclude directory `target`, used in Rust

### DIFF
--- a/package.json
+++ b/package.json
@@ -384,6 +384,7 @@
             "**/bower_components",
             "**/dist",
             "**/build",
+            "**/target",
             "**/out",
             "**/output",
             "**/_output",


### PR DESCRIPTION
Inside target, there are hundreds of binary artifacts (just slowing down search), but also, if user generated docs (`cargo doc`), source code and documentation of all dependencies.