### PR TITLE
Added option to customize project display template when project is completed 

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ It adds 6 shortcuts when editing a `Todo` file:
   "todo.statistics.statusbar.command": "", // Command to execute on click
   "todo.statistics.statusbar.priority": -1, // The priority of this item. Higher value means the item should be shown more to the left
   "todo.statistics.statusbar.text": "$(check) [finished]/[all] ([percentage]%)", // Template used for rendering the text
+  "todo.statistics.statusbar.done": "", // Template used for rendering the text when project is done
   "todo.statistics.statusbar.tooltip": "[pending] Pending - [done] Done - [cancelled] Cancelled", // Template used for rendering the tooltip
   "todo.embedded.regex": "(?:<!-- *)?(?:#|//|/\\*+|<!--|--|\\* @|\\{!|\\{\\{!--|\\{\\{!) *(TODO|FIXME|FIX|BUG|UGLY|HACK|NOTE|IDEA|REVIEW|DEBUG|OPTIMIZE)(?:\\s*\\([^)]+\\))?:?(?!\\w)(?: *-->| *\\*/| *!}| *--}}| *}}|(?= *(?:[^:]//|/\\*+|<!--|@|--|\\{!|\\{\\{!--|\\{\\{!))|((?: +[^\\n@]*?)(?= *(?:[^:]//|/\\*+|<!--|@|--(?!>)|\\{!|\\{\\{!--|\\{\\{!))|(?: +[^@\\n]+)?))", // Regex used for finding embedded todos, requires double escaping
   "todo.embedded.regexFlags": "gi", // Regex flags to use

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ It adds 6 shortcuts when editing a `Todo` file:
   "todo.timer.statusbar.priority": -10, // The priority of this item. Higher value means the item should be shown more to the left
   "todo.statistics.project.enabled": "global.projects < 100 && project.pending > 0", // Show statistics next to a project, boolean or JS expression
   "todo.statistics.project.text": "([pending]) [est]", // Template used for rendering the text
+  "todo.statistics.project.done": "", // Template used for rendering the text when project is done
   "todo.statistics.statusbar.enabled": "global.all > 0", // Show statistics in the statusbar, boolean or JS expression
   "todo.statistics.statusbar.ignoreArchive": true, // Ignore the archive when rendering statistics in the statusbar
   "todo.statistics.statusbar.alignment": "left", // Should the item be placed to the left or right?
@@ -119,7 +120,6 @@ It adds 6 shortcuts when editing a `Todo` file:
   "todo.statistics.statusbar.command": "", // Command to execute on click
   "todo.statistics.statusbar.priority": -1, // The priority of this item. Higher value means the item should be shown more to the left
   "todo.statistics.statusbar.text": "$(check) [finished]/[all] ([percentage]%)", // Template used for rendering the text
-  "todo.statistics.statusbar.done": "", // Template used for rendering the text when project is done
   "todo.statistics.statusbar.tooltip": "[pending] Pending - [done] Done - [cancelled] Cancelled", // Template used for rendering the tooltip
   "todo.embedded.regex": "(?:<!-- *)?(?:#|//|/\\*+|<!--|--|\\* @|\\{!|\\{\\{!--|\\{\\{!) *(TODO|FIXME|FIX|BUG|UGLY|HACK|NOTE|IDEA|REVIEW|DEBUG|OPTIMIZE)(?:\\s*\\([^)]+\\))?:?(?!\\w)(?: *-->| *\\*/| *!}| *--}}| *}}|(?= *(?:[^:]//|/\\*+|<!--|@|--|\\{!|\\{\\{!--|\\{\\{!))|((?: +[^\\n@]*?)(?= *(?:[^:]//|/\\*+|<!--|@|--(?!>)|\\{!|\\{\\{!--|\\{\\{!))|(?: +[^@\\n]+)?))", // Regex used for finding embedded todos, requires double escaping
   "todo.embedded.regexFlags": "gi", // Regex flags to use

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ This extension supports various providers for searching for embedded todos, it'l
 
 ## Statistics Tokens
 
-The following tokens can be used in `todo.statistics.project.text`, `todo.statistics.statusbar.text` and `todo.statistics.statusbar.tooltip`, they will be replaced with the value they represent.
+The following tokens can be used in `todo.statistics.project.text`, `todo.statistics.project.done`, `todo.statistics.statusbar.text` and `todo.statistics.statusbar.tooltip`, they will be replaced with the value they represent.
 
 | Token          | Value                            |
 |----------------|----------------------------------|

--- a/contributing.md
+++ b/contributing.md
@@ -1,5 +1,0 @@
-Fork, clone project
-
-```
-npm install
-```

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,5 @@
+Fork, clone project
+
+```
+npm install
+```

--- a/package.json
+++ b/package.json
@@ -436,12 +436,17 @@
             "string"
           ],
           "description": "Show statistics next to a project, boolean or JS expression",
-          "default": "global.projects < 100 && project.pending > 0"
+          "default": "global.projects < 100"
         },
         "todo.statistics.project.text": {
           "type": "string",
-          "description": "Template used for rendering the text",
+          "description": "Template used for rendering project text",
           "default": "([pending]) [est]"
+        },
+        "todo.statistics.project.done": {
+          "type": "string",
+          "description": "Template used for rendering project text when all done",
+          "default": ""
         },
         "todo.statistics.statusbar.enabled": {
           "type": [

--- a/src/todo/decorators/project.ts
+++ b/src/todo/decorators/project.ts
@@ -90,6 +90,7 @@ class Project extends Line {
     StatisticsTypes.reset ( textEditor );
 
     const template = Config.getKey ( 'statistics.project.text' ),
+          templateDone = Config.getKey( 'statistics.project.done'),  // Use different template if all items are marked done
           basicRanges = [],
           statisticsData = [];
 
@@ -100,12 +101,12 @@ class Project extends Line {
             withStatistics = Utils.statistics.condition.is ( condition, Utils.statistics.tokens.global, tokens );
 
       if ( withStatistics ) {
+          const contentTemplate = tokens.pending === 0 ? templateDone : template
 
-        const contentText = Utils.statistics.template.render ( template, tokens ),
-              type = StatisticsTypes.get ( contentText, textEditor );
+          const contentText = Utils.statistics.template.render ( contentTemplate, tokens ),
+                type = StatisticsTypes.get ( contentText, textEditor );
 
-        statisticsData.push ({ type, ranges });
-
+          statisticsData.push ({ type, ranges });
       } else {
 
         basicRanges.push ( ...ranges );

--- a/src/todo/document.ts
+++ b/src/todo/document.ts
@@ -20,11 +20,11 @@ class Document {
 
     if ( _.isString ( res ) ) {
 
-      this.text = res;
+      this.text = <string>res;
 
     } else {
 
-      if ( 'document' in res ) { // => vscode.TextEditor
+      if ( 'document' in <vscode.TextDocument|vscode.TextEditor>res ) { // => vscode.TextEditor
 
         this.textEditor = res as vscode.TextEditor; //TSC
         this.textDocument = this.textEditor.document;

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -122,7 +122,7 @@ const Time = {
 
     } else {
 
-      to = to.replace ( / and /gi, ' ' );
+      to = (to as string).replace ( / and /gi, ' ' );
       to = to.replace ( /(\d)(ms|s|m|h|d|w|y)(\d)/gi, '$1$2 $3' );
 
       if ( /^\s*\d+\s*$/.test ( to ) ) return 0;


### PR DESCRIPTION
Issue #212

I thought it would be cool to display "lasted" time even when all items in a project were marked done.

I removed the `&& project.pending > 0` requirement for showing statistics, and added another property `todo.statistics.project.done` to create a secondary template. This defaults to "" so original functionality doesn't change

Setting it to "`[lasted]`" gets me the results I'm looking for

<img width="559" alt="Screen Shot 2019-07-30 at 12 27 05 PM" src="https://user-images.githubusercontent.com/4062679/62159401-7fdd7780-b2c6-11e9-8443-d3730c48e1a0.png">

I also added some type castings in `document.ts` and `time.ts` because typescript was getting angry and couldn't automatically infer it from the if statements, throwing errors