### PR TITLE
Fixed slow update of statistics decorations (fixes #210)

### DIFF
--- a/src/todo/decorators/project.ts
+++ b/src/todo/decorators/project.ts
@@ -21,11 +21,10 @@ const PROJECT_BASIC = vscode.window.createTextEditorDecorationType ({
   }
 });
 
-const PROJECT_STATISTICS = () => ({
+const PROJECT_STATISTICS = vscode.window.createTextEditorDecorationType ({
   color: Consts.colors.project,
   rangeBehavior: vscode.DecorationRangeBehavior.OpenClosed,
   after: {
-    contentText: undefined,
     color: Consts.colors.projectStatistics,
     margin: '.05em 0 .05em .5em',
     textDecoration: ';font-size: .9em'
@@ -43,29 +42,6 @@ const PROJECT_STATISTICS = () => ({
     }
   }
 });
-
-const StatisticsTypes = {
-
-  types: {},
-
-  get ( contentText: string, textEditor: vscode.TextEditor ) {
-    const decorations = PROJECT_STATISTICS ();
-    decorations.after.contentText = contentText;
-    const type = vscode.window.createTextEditorDecorationType ( decorations );
-    const id = textEditor.document.uri.fsPath;
-    if ( !StatisticsTypes.types[id] ) StatisticsTypes.types[id] = [];
-    StatisticsTypes.types[id].push ( type );
-    return type;
-  },
-
-  reset ( textEditor: vscode.TextEditor ) {
-    const id = textEditor.document.uri.fsPath;
-    if ( !StatisticsTypes.types[id] ) return;
-    StatisticsTypes.types[id].forEach ( type => textEditor.setDecorations ( type, [] ) );
-    StatisticsTypes.types[id] = [];
-  }
-
-};
 
 /* PROJECT */
 
@@ -87,11 +63,11 @@ class Project extends Line {
 
     const textEditor = projects.length ? projects[0].textEditor : vscode.window.activeTextEditor;
 
-    StatisticsTypes.reset ( textEditor );
+    textEditor.setDecorations ( PROJECT_STATISTICS, [] )
 
     const template = Config.getKey ( 'statistics.project.text' ),
           basicRanges = [],
-          statisticsData = [];
+          statisticRanges = [];
 
     projects.forEach ( project => {
 
@@ -101,10 +77,15 @@ class Project extends Line {
 
       if ( withStatistics ) {
 
-        const contentText = Utils.statistics.template.render ( template, tokens ),
-              type = StatisticsTypes.get ( contentText, textEditor );
-
-        statisticsData.push ({ type, ranges });
+        const contentText = Utils.statistics.template.render ( template, tokens )
+        statisticRanges.push( ...ranges.map ( range => ({
+          range,
+          renderOptions: {
+            after: {
+              contentText
+            }
+          }
+        })))
 
       } else {
 
@@ -119,7 +100,10 @@ class Project extends Line {
         type: PROJECT_BASIC,
         ranges: basicRanges
       },
-      ...statisticsData
+      {
+        type: PROJECT_STATISTICS,
+        ranges: statisticRanges
+      }
     ];
 
   }


### PR DESCRIPTION
@marvinhagemeister and me invested some time tracking down the occasional sluggishness of the extension as I originally reported in #210. We managed to isolate the problem: the repetitive call to `vscode.window.createTextEditorDecorationType` creates a new decoration type for each decoration. This is not necessary, since we can just reuse the same decoration type for all decorations/ranges. This is also what's recommended by the VS Code team, as can be seen in the [decorations example](https://github.com/microsoft/vscode-extension-samples/blob/main/decorator-sample/src/extension.ts).

__Example CPU profile of `master`__:

<img width="1439" alt="Bildschirmfoto 2023-01-31 um 23 20 10" src="https://user-images.githubusercontent.com/932156/215897002-5f1f9f4b-7fff-4910-b089-0f39f2fcad15.png">

__Example CPU profile of this branch__:

<img width="1439" alt="Bildschirmfoto 2023-01-31 um 23 20 19" src="https://user-images.githubusercontent.com/932156/215896986-86e473ad-8d3e-46b8-bddf-94988c6ae7e1.png">

As a result, editing feels much more responsive, and the CPU spikes are also gone!