### PR TITLE
Bump moment from 2.22.2 to 2.29.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1048,7 +1048,7 @@
     "memoize-decorator": "^1.0.2",
     "micromatch": "^3.1.10",
     "mkdirp": "^0.5.5",
-    "moment": "2.22.2",
+    "moment": "2.29.4",
     "moment-precise-range-plugin": "^1.3.0",
     "pify": "^3.0.0",
     "sha1": "^1.1.1",


### PR DESCRIPTION
Bump moment from 2.22.2 to 2.29.4
Bumps [moment](https://github.com/moment/moment) from 2.22.2 to 2.29.4.
- [Changelog](https://github.com/moment/moment/blob/develop/CHANGELOG.md)
- [Commits](https://github.com/moment/moment/compare/2.22.2...2.29.4)