### PR TITLE
Use node: prefix for Node.js builtins

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2,7 +2,7 @@
 /* IMPORT */
 
 import * as _ from 'lodash';
-import * as path from 'path';
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 import Config from './config';
 import Consts from './consts';

--- a/src/utils/embedded/index.ts
+++ b/src/utils/embedded/index.ts
@@ -2,8 +2,8 @@
 /* IMPORT */
 
 import * as execa from 'execa';
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 import Config from '../../config';
 import AG from './providers/ag';

--- a/src/utils/embedded/providers/abstract.ts
+++ b/src/utils/embedded/providers/abstract.ts
@@ -2,8 +2,8 @@
 /* IMPORT */
 
 import * as _ from 'lodash';
-import * as querystring from 'querystring';
-import * as path from 'path';
+import * as querystring from 'node:querystring';
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 import Config from '../../../config';
 import EmbeddedView from '../../../views/embedded';

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -2,9 +2,9 @@
 /* IMPORT */
 
 import * as _ from 'lodash';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import * as mkdirp from 'mkdirp';
-import * as path from 'path';
+import * as path from 'node:path';
 import * as pify from 'pify';
 import * as vscode from 'vscode';
 

--- a/src/utils/folder.ts
+++ b/src/utils/folder.ts
@@ -4,7 +4,7 @@
 import * as _ from 'lodash';
 import * as absolute from 'absolute';
 import * as findUp from 'find-up';
-import * as path from 'path';
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 
 /* FOLDER */

--- a/src/utils/todo.ts
+++ b/src/utils/todo.ts
@@ -2,7 +2,7 @@
 /* IMPORT */
 
 import * as _ from 'lodash';
-import * as path from 'path';
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 import Config from '../config';
 import File from './file';

--- a/src/utils/view.ts
+++ b/src/utils/view.ts
@@ -2,9 +2,9 @@
 /* IMPORT */
 
 import * as _ from 'lodash';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import * as mkdirp from 'mkdirp';
-import * as path from 'path';
+import * as path from 'node:path';
 import * as sha1 from 'sha1';
 import * as vscode from 'vscode';
 import Consts from '../consts';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 
 /* IMPORT */
 
-const path = require ( 'path' );
+const path = require ( 'node:path' );
 
 /* CONFIG */
 


### PR DESCRIPTION
All Node.js builtin imports now use the node: prefix for easier grepping.